### PR TITLE
Use COPY when you don't need the magic of ADD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,9 @@ RUN apt-get update \
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-ADD files/apache-vhost.conf /etc/apache2/sites-enabled/000-default.conf
-ADD files/php-config.ini /usr/local/etc/php/conf.d/php-config.ini
-ADD files/php-timezone.ini /usr/local/etc/php/conf.d/php-timezone.ini
+COPY files/apache-vhost.conf /etc/apache2/sites-enabled/000-default.conf
+COPY files/php-config.ini /usr/local/etc/php/conf.d/php-config.ini
+COPY files/php-timezone.ini /usr/local/etc/php/conf.d/php-timezone.ini
 
 RUN a2enmod rewrite
 


### PR DESCRIPTION
Note that the [Best practices for writing Dockerfiles](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy) suggests using COPY where the magic of ADD is not required. Otherwise you (since you had to lookup this answer) are likely to get surprised someday when you mean to copy keep_this_archive_intact.tar.gz into your container, but instead you spray the contents onto your filesystem.

Source: https://stackoverflow.com/a/24958548/1754123